### PR TITLE
[feature/jwthotfix] jwt API값 인식 오류 해결

### DIFF
--- a/src/main/java/com/feelmycode/parabole/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/feelmycode/parabole/global/config/JwtAuthenticationFilter.java
@@ -42,10 +42,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 request.setAttribute("imageUrl", claims.get("imageUrl", String.class));
                 request.setAttribute("role", claims.get("role", String.class));
                 if (claims.get("role", String.class).equals("ROLE_SELLER")) {
-                    request.setAttribute("sellerId", Long.class);
-                    request.setAttribute("sellerStorename", String.class);
+                    request.setAttribute("sellerId", claims.get("sellerId", Long.class));
+                    request.setAttribute("sellerStorename", claims.get("sellerStorename", String.class));
                 }
-                request.setAttribute("authProvider", String.class);
+                request.setAttribute("authProvider", claims.get("authProvider", String.class));
+
 
             }
         } catch (Exception ex) {


### PR DESCRIPTION
## 작업한 내용
!HOTFIX: jwt API값 인식 오류 해결

## 리뷰 가이드 
백엔드 API 에서 sellerId 사용하시는 분들은 이제 값 잘 들어갈 겁니다.
그 부분을 확인해보시면 되어요

## 테스트 결과
![image](https://user-images.githubusercontent.com/46639550/201240253-52eb4ec7-40f1-4fdc-8e93-0b2ade97b66e.png)
